### PR TITLE
Fix server open connection leaks

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -236,11 +236,13 @@ func (s *server) handle(client net.Conn) {
 	sig := make(chan struct{})
 
 	go func() {
+		defer close(sig)
+
 		var buf [1]byte
 		if _, err := io.ReadFull(client, buf[:]); err != nil {
+			client.Close()
 			return
 		}
-		close(sig)
 
 		for _, m := range s.mux {
 			if m.mux != buf[0] {


### PR DESCRIPTION
Hi,

I think we should close connection & sig in the server after io.ReadFull errors.

Some healthcheck method (K8s, AWS ELB Target Groups, etc.) will close connection and trigger the EOF error here.