### PR TITLE
Pass source connection to batch object

### DIFF
--- a/lj/lj.go
+++ b/lj/lj.go
@@ -18,17 +18,24 @@
 // Package lj implements common lumberjack types and functions.
 package lj
 
+import "net"
+
 // Batch is an ACK-able batch of events as has been received by lumberjack
 // server implemenentations. Batches must be ACKed, for the server
 // implementations returning an ACK to it's clients.
 type Batch struct {
 	Events []interface{}
+	Conn   net.Conn
 	ack    chan struct{}
 }
 
 // NewBatch creates a new ACK-able batch.
-func NewBatch(evts []interface{}) *Batch {
-	return &Batch{evts, make(chan struct{})}
+func NewBatch(evts []interface{}, conn net.Conn) *Batch {
+	return &Batch{
+		Events: evts,
+		Conn:   conn,
+		ack:    make(chan struct{}),
+	}
 }
 
 // ACK acknowledges a batch initiating propagation of ACK to clients.

--- a/server/mux.go
+++ b/server/mux.go
@@ -22,18 +22,18 @@ import (
 	"net"
 )
 
+type MuxConn struct {
+	net.Conn
+}
+
 type muxListener struct {
 	net.Listener
 	ch chan net.Conn
 }
 
-type muxConn struct {
-	net.Conn
-}
-
 type versionConn struct {
 	net.Conn
-	parent *muxConn
+	parent *MuxConn
 	v      byte
 }
 
@@ -62,8 +62,8 @@ func (l *muxListener) Close() error {
 	return nil
 }
 
-func newMuxConn(v byte, c net.Conn) *muxConn {
-	mc := &muxConn{}
+func newMuxConn(v byte, c net.Conn) *MuxConn {
+	mc := &MuxConn{}
 	vc := &versionConn{c, mc, v}
 	mc.Conn = vc
 	return mc

--- a/server/v1/reader.go
+++ b/server/v1/reader.go
@@ -76,7 +76,7 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, err
 	}
 
-	return lj.NewBatch(events), nil
+	return lj.NewBatch(events, r.conn), nil
 }
 
 func (r *reader) readEvents(in io.Reader, events []interface{}) ([]interface{}, error) {

--- a/server/v2/reader.go
+++ b/server/v2/reader.go
@@ -80,7 +80,7 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, err
 	}
 
-	return lj.NewBatch(events), nil
+	return lj.NewBatch(events, r.conn), nil
 }
 
 func (r *reader) readEvents(in io.Reader, events []interface{}) ([]interface{}, error) {


### PR DESCRIPTION
This PR adds a `Conn` field to `lj.Batch`. This field is set to the source connection that the batch comes from.

My use case is, that this `net.Conn` is actually a `*tls.Conn` and and want to access the TLS peer certificate that the client is using.

Thanks to this PR I can now do :

```go
batch := handler.Receive()
batch.Conn.(*server.MuxConn).Conn.(*tls.Conn).ConnectionState().PeerCertificates[0].Subject.CommonName
```