### PR TITLE
Update Go version and dependencies

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.14.13'
+            values '1.19'
           }
           axis {
             name 'PLATFORM'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Require Go 1.17 to use module. [#28](https://github.com/elastic/go-lumber/pull/28)
+
 ### Deprecated
 
 ### Removed
@@ -18,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix go-routine and file descriptor leak if an error occurs during connection startup. #15
+- Fix goroutine and file descriptor leak if an error occurs during connection startup. [#15](https://github.com/elastic/go-lumber/pull/15)
 
-[Unreleased]: https://github.com/elastic/go-concert/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/elastic/go-lumber/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/elastic/go-concert/compare/v0.1.0...v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/elastic/go-lumber
 
-go 1.14
+go 1.17
 
-require github.com/klauspost/compress v1.11.2
+require github.com/klauspost/compress v1.15.9

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=
-github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=


### PR DESCRIPTION
Use Go 1.17 for module.
Build/test on CI with Go 1.19.
Update klauspost/compress.

Closes #27