### PR TITLE
Project cleanup - lint, typos, golangci-lint, license

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - uses: actions/checkout@v3
+
+      - name: check go.mod
+        run: |
+          go mod tidy
+          git diff-index --quiet HEAD
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,85 @@
+---
+
+run:
+  issues-exit-code: 1
+  modules-download-mode: readonly
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unused
+    - varcheck
+    - depguard
+    - errorlint
+    - gofumpt
+    - goimports
+    - godox
+    - goheader
+    - misspell
+    - prealloc
+    - unconvert
+    - revive
+  fast: false
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/elastic/go-lumber
+  gofumpt:
+    extra-rules: true
+  revive:
+    enable-all-rules: false
+    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+    rules:
+      - name: bare-return
+      - name: call-to-gc
+      - name: confusing-results
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: deep-exit
+      - name: defer
+      - name: duplicated-imports
+      - name: early-return
+      - name: empty-block
+      - name: error-strings
+      - name: errorf
+      - name: exported
+        arguments:
+          - checkPrivateReceivers
+      - name: imports-blacklist
+        arguments:
+          - github.com/pkg/errors
+      - name: increment-decrement
+      - name: range
+      - name: range-val-address
+      - name: range-val-in-closure
+      - name: receiver-naming
+      - name: struct-tag
+      - name: time-naming
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: unused-receiver
+      - name: var-declaration
+      - name: waitgroup-by-value
+  stylecheck:
+    checks:
+      - all
+
+issues:
+  include:
+   # If you're going to write a comment follow the conventions.
+   # https://go.dev/doc/effective_go#commentary.
+   # comment on exported (.+) should be of the form "(.+)..."
+   - EXC0014

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,202 @@
-Copyright (c) 2012–2016 Elasticsearch <http://www.elastic.co>
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/client/v2/async.go
+++ b/client/v2/async.go
@@ -113,7 +113,7 @@ func (c *AsyncClient) Close() error {
 }
 
 // Send publishes a new batch of events by JSON-encoding given batch.
-// Send blocks if maximum number of allowed asynchrounous calls is still active.
+// Send blocks if maximum number of allowed asynchronous calls is still active.
 // Upon completion cb will be called with last ACKed index into active batch.
 // Returns error if communication or serialization to JSON failed.
 func (c *AsyncClient) Send(cb AsyncSendCallback, data []interface{}) error {

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -48,11 +48,9 @@ var (
 	empty4 = []byte{0, 0, 0, 0}
 )
 
-var (
-	// ErrProtocolError is returned if an protocol error was detected in the
-	// conversation with lumberjack server.
-	ErrProtocolError = errors.New("lumberjack protocol error")
-)
+// ErrProtocolError is returned if an protocol error was detected in the
+// conversation with lumberjack server.
+var ErrProtocolError = errors.New("lumberjack protocol error")
 
 // NewWithConn create a new lumberjack client with an existing and active
 // connection.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -48,7 +48,7 @@ var (
 	empty4 = []byte{0, 0, 0, 0}
 )
 
-// ErrProtocolError is returned if an protocol error was detected in the
+// ErrProtocolError is returned if a protocol error was detected in the
 // conversation with lumberjack server.
 var ErrProtocolError = errors.New("lumberjack protocol error")
 
@@ -178,13 +178,13 @@ func (c *Client) ReceiveACK() (uint32, error) {
 	}
 
 	var msg [6]byte
-	ackbytes := 0
-	for ackbytes < 6 {
-		n, err := c.conn.Read(msg[ackbytes:])
+	ackBytes := 0
+	for ackBytes < 6 {
+		n, err := c.conn.Read(msg[ackBytes:])
 		if err != nil {
 			return 0, err
 		}
-		ackbytes += n
+		ackBytes += n
 	}
 
 	// validate response
@@ -202,7 +202,7 @@ func (c *Client) AwaitACK(count uint32) (uint32, error) {
 	var ackSeq uint32
 	var err error
 
-	// read until all acks
+	// read until all ACKs
 	for ackSeq < count {
 		ackSeq, err = c.ReceiveACK()
 		if err != nil {

--- a/cmd/tst-lj/main.go
+++ b/cmd/tst-lj/main.go
@@ -21,7 +21,7 @@
 // server supports all lumberjack protocol versions, which must be explicitely enabled
 // from command line. For printing list of known command line flags run:
 //
-//  tst-lj -h
+//	tst-lj -h
 package main
 
 import (

--- a/cmd/tst-lj/main.go
+++ b/cmd/tst-lj/main.go
@@ -30,6 +30,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/elastic/go-lumber/lj"
@@ -64,7 +65,7 @@ func main() {
 	}
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, os.Kill)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sig
 		if rl != nil {

--- a/cmd/tst-lj/main.go
+++ b/cmd/tst-lj/main.go
@@ -18,7 +18,7 @@
 // Lumberjack server test tool.
 //
 // Create lumberjack server endpoint ACKing all received batches only. The
-// server supports all lumberjack protocol versions, which must be explicitely enabled
+// server supports all lumberjack protocol versions, which must be explicitly enabled
 // from command line. For printing list of known command line flags run:
 //
 //	tst-lj -h

--- a/cmd/tst-send/main.go
+++ b/cmd/tst-send/main.go
@@ -19,7 +19,7 @@
 //
 // For list of known command line flags run:
 //
-//  tst-send -h
+//	tst-send -h
 package main
 
 import (
@@ -105,8 +105,7 @@ func main() {
 	}
 }
 
-var (
-	text = strings.Split(`Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+var text = strings.Split(`Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
 sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
 sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
 clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
@@ -114,7 +113,6 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
 no sea takimata sanctus est Lorem ipsum dolor sit amet.`, "\n")
-)
 
 func makeEvent() interface{} {
 	line := text[rand.Intn(len(text))]

--- a/lj/lj.go
+++ b/lj/lj.go
@@ -18,17 +18,17 @@
 // Package lj implements common lumberjack types and functions.
 package lj
 
-// Batch is an ACK-able batch of events as has been received by lumberjack
-// server implemenentations. Batches must be ACKed, for the server
-// implementations returning an ACK to it's clients.
+// Batch is an ACK-able batch of events that has been received by lumberjack
+// server implementations. Batches must be ACKed for the server
+// implementations returning an ACK to its clients.
 type Batch struct {
 	Events []interface{}
 	ack    chan struct{}
 }
 
 // NewBatch creates a new ACK-able batch.
-func NewBatch(evts []interface{}) *Batch {
-	return &Batch{evts, make(chan struct{})}
+func NewBatch(events []interface{}) *Batch {
+	return &Batch{events, make(chan struct{})}
 }
 
 // ACK acknowledges a batch initiating propagation of ACK to clients.

--- a/log/log.go
+++ b/log/log.go
@@ -42,13 +42,13 @@ func Printf(format string, args ...interface{}) {
 	Logger.Printf(format, args...)
 }
 
-// Println calls Logger.Println to print to the standard logger. Arguments are
+// Println calls Logger.Println to write to the standard logger. Arguments are
 // handled in the manner of fmt.Println.
 func Println(args ...interface{}) {
 	Logger.Println(args...)
 }
 
-// Print calls Logger.Print to print to the standard logger. Arguments are
+// Print calls Logger.Print to write to the standard logger. Arguments are
 // handled in the manner of fmt.Print.
 func Print(args ...interface{}) {
 	Logger.Print(args...)

--- a/protocol/v1/protocol.go
+++ b/protocol/v1/protocol.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package v1 proviades common lumberjack protocol version 1 definitions.
+// Package v1 provides common lumberjack protocol version 1 definitions.
 package v1
 
 // Version declares the protocol revision supported by this package.

--- a/protocol/v2/protocol.go
+++ b/protocol/v2/protocol.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package v2 proviades common lumberjack protocol version 2 definitions.
+// Package v2 provides common lumberjack protocol version 2 definitions.
 package v2
 
 // Version declares the protocol revision supported by this package.

--- a/server/internal/handler.go
+++ b/server/internal/handler.go
@@ -178,5 +178,4 @@ func (h *defaultHandler) waitACK(batch *lj.Batch) error {
 			}
 		}
 	}
-
 }

--- a/server/internal/handler.go
+++ b/server/internal/handler.go
@@ -130,6 +130,7 @@ func (h *defaultHandler) ackLoop() {
 	// Stop ACKing batches in case of error, forcing client to reconnect
 	defer func() {
 		log.Println("drain ack loop")
+		//nolint:revive // This drains the channel.
 		for range h.ch {
 		}
 	}()

--- a/server/internal/handler.go
+++ b/server/internal/handler.go
@@ -73,8 +73,6 @@ func DefaultHandler(
 }
 
 func (h *defaultHandler) Run() {
-	defer close(h.ch)
-
 	// start async routine for returning ACKs to client.
 	// Sends ACK of 0 every 'keepalive' seconds to signal
 	// client the batch still being in pipeline
@@ -94,6 +92,7 @@ func (h *defaultHandler) Stop() {
 func (h *defaultHandler) handle() error {
 	log.Printf("Start client handler")
 	defer log.Printf("client handler stopped")
+	defer close(h.ch)
 	defer h.Stop()
 
 	for {

--- a/server/mux.go
+++ b/server/mux.go
@@ -37,10 +37,8 @@ type versionConn struct {
 	v      byte
 }
 
-var (
-	// ErrListenerClosed indicates the multiplexing network listener being closed.
-	ErrListenerClosed = errors.New("listener closed")
-)
+// ErrListenerClosed indicates the multiplexing network listener being closed.
+var ErrListenerClosed = errors.New("listener closed")
 
 func newMuxListener(l net.Listener) *muxListener {
 	return &muxListener{l, make(chan net.Conn, 1)}

--- a/server/server.go
+++ b/server/server.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/elastic/go-lumber/lj"
 	"github.com/elastic/go-lumber/log"
-	"github.com/elastic/go-lumber/server/v1"
-	"github.com/elastic/go-lumber/server/v2"
+	v1 "github.com/elastic/go-lumber/server/v1"
+	v2 "github.com/elastic/go-lumber/server/v2"
 )
 
 // Server serves multiple lumberjack clients.
@@ -64,7 +64,7 @@ type muxServer struct {
 
 // ErrNoVersionEnabled indicates no lumberjack protocol version being enabled
 // when instantiating a server.
-var ErrNoVersionEnabled = errors.New("No protocol version enabled")
+var ErrNoVersionEnabled = errors.New("no protocol version enabled")
 
 // NewWithListener creates a new Server using an existing net.Listener. Use
 // options V1 and V2 to enable wanted protocol versions.

--- a/server/server.go
+++ b/server/server.go
@@ -62,11 +62,9 @@ type muxServer struct {
 	server Server
 }
 
-var (
-	// ErrNoVersionEnabled indicates no lumberjack protocol version being enabled
-	// when instantiating a server.
-	ErrNoVersionEnabled = errors.New("No protocol version enabled")
-)
+// ErrNoVersionEnabled indicates no lumberjack protocol version being enabled
+// when instantiating a server.
+var ErrNoVersionEnabled = errors.New("No protocol version enabled")
 
 // NewWithListener creates a new Server using an existing net.Listener. Use
 // options V1 and V2 to enable wanted protocol versions.

--- a/server/v1/server.go
+++ b/server/v1/server.go
@@ -30,7 +30,7 @@ type Server struct {
 	s *internal.Server
 }
 
-// ErrProtocolError is returned if an protocol error was detected in the
+// ErrProtocolError is returned if a protocol error was detected in the
 // conversation with lumberjack server.
 var ErrProtocolError = errors.New("lumberjack protocol error")
 

--- a/server/v1/server.go
+++ b/server/v1/server.go
@@ -30,11 +30,9 @@ type Server struct {
 	s *internal.Server
 }
 
-var (
-	// ErrProtocolError is returned if an protocol error was detected in the
-	// conversation with lumberjack server.
-	ErrProtocolError = errors.New("lumberjack protocol error")
-)
+// ErrProtocolError is returned if an protocol error was detected in the
+// conversation with lumberjack server.
+var ErrProtocolError = errors.New("lumberjack protocol error")
 
 // NewWithListener creates a new Server using an existing net.Listener.
 func NewWithListener(l net.Listener, opts ...Option) (*Server, error) {

--- a/server/v1/writer.go
+++ b/server/v1/writer.go
@@ -55,7 +55,7 @@ func (w *writer) ACK(n int) error {
 	return nil
 }
 
-func (w *writer) Keepalive(n int) error {
+func (*writer) Keepalive(_ int) error {
 	// keepalive not supported by v1
 	return nil
 }

--- a/server/v1/writer.go
+++ b/server/v1/writer.go
@@ -55,7 +55,7 @@ func (w *writer) ACK(n int) error {
 	return nil
 }
 
-func (*writer) Keepalive(_ int) error {
+func (*writer) Keepalive(int) error {
 	// keepalive not supported by v1
 	return nil
 }

--- a/server/v2/server.go
+++ b/server/v2/server.go
@@ -30,7 +30,7 @@ type Server struct {
 	s *internal.Server
 }
 
-// ErrProtocolError is returned if an protocol error was detected in the
+// ErrProtocolError is returned if a protocol error was detected in the
 // conversation with lumberjack server.
 var ErrProtocolError = errors.New("lumberjack protocol error")
 

--- a/server/v2/server.go
+++ b/server/v2/server.go
@@ -30,11 +30,9 @@ type Server struct {
 	s *internal.Server
 }
 
-var (
-	// ErrProtocolError is returned if an protocol error was detected in the
-	// conversation with lumberjack server.
-	ErrProtocolError = errors.New("lumberjack protocol error")
-)
+// ErrProtocolError is returned if an protocol error was detected in the
+// conversation with lumberjack server.
+var ErrProtocolError = errors.New("lumberjack protocol error")
 
 // NewWithListener creates a new Server using an existing net.Listener.
 func NewWithListener(l net.Listener, opts ...Option) (*Server, error) {


### PR DESCRIPTION
Cleanup linter issues.

Enable `golangci-lint` via Github Actions.

Copy full ASL 2.0 license text.