### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -7,6 +7,10 @@ on:
     workflows: [ci]
     types: [completed]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   report:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
