### PR TITLE
server: add configurable maximum window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add configurable maximum window size. [#44](https://github.com/elastic/go-lumber/pull/44)
+
 ### Added
 
 - Add connection metadata to `lj.Batch`. [#29](https://github.com/elastic/go-lumber/pull/29)

--- a/server/opts.go
+++ b/server/opts.go
@@ -29,14 +29,19 @@ import (
 // Option type for configuring server run options.
 type Option func(*options) error
 
+// DefaultMaxWindowSize is the default upper bound on the number of events
+// a client may announce in a single batch window frame.
+const DefaultMaxWindowSize = 10000
+
 type options struct {
-	timeout   time.Duration
-	keepalive time.Duration
-	decoder   jsonDecoder
-	tls       *tls.Config
-	v1        bool
-	v2        bool
-	ch        chan *lj.Batch
+	timeout       time.Duration
+	keepalive     time.Duration
+	maxWindowSize int
+	decoder       jsonDecoder
+	tls           *tls.Config
+	v1            bool
+	v2            bool
+	ch            chan *lj.Batch
 }
 
 type jsonDecoder func([]byte, interface{}) error
@@ -106,14 +111,25 @@ func V2(b bool) Option {
 	}
 }
 
+// MaxWindowSize configures the maximum number of events a client may
+// announce in a single batch window frame. Frames exceeding this limit
+// are rejected. A value of zero or negative disables the check.
+func MaxWindowSize(n int) Option {
+	return func(opt *options) error {
+		opt.maxWindowSize = n
+		return nil
+	}
+}
+
 func applyOptions(opts []Option) (options, error) {
 	o := options{
-		decoder:   json.Unmarshal,
-		timeout:   30 * time.Second,
-		keepalive: 3 * time.Second,
-		v1:        true,
-		v2:        true,
-		tls:       nil,
+		decoder:       json.Unmarshal,
+		timeout:       30 * time.Second,
+		keepalive:     3 * time.Second,
+		maxWindowSize: DefaultMaxWindowSize,
+		v1:            true,
+		v2:            true,
+		tls:           nil,
 	}
 
 	for _, opt := range opts {

--- a/server/opts.go
+++ b/server/opts.go
@@ -36,7 +36,7 @@ const DefaultMaxWindowSize = 10000
 type options struct {
 	timeout       time.Duration
 	keepalive     time.Duration
-	maxWindowSize int
+	maxWindowSize uint32
 	decoder       jsonDecoder
 	tls           *tls.Config
 	v1            bool
@@ -114,7 +114,7 @@ func V2(b bool) Option {
 // MaxWindowSize configures the maximum number of events a client may
 // announce in a single batch window frame. Frames exceeding this limit
 // are rejected. A value of zero or negative disables the check.
-func MaxWindowSize(n int) Option {
+func MaxWindowSize(n uint32) Option {
 	return func(opt *options) error {
 		opt.maxWindowSize = n
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -156,6 +156,7 @@ func newServer(l net.Listener, opts ...Option) (Server, error) {
 		servers = append(servers, func(l net.Listener) (Server, byte, error) {
 			s, err := v1.NewWithListener(l,
 				v1.Timeout(cfg.timeout),
+				v1.MaxWindowSize(cfg.maxWindowSize),
 				v1.Channel(cfg.ch),
 				v1.TLS(cfg.tls))
 			return s, '1', err
@@ -166,6 +167,7 @@ func newServer(l net.Listener, opts ...Option) (Server, error) {
 			s, err := v2.NewWithListener(l,
 				v2.Keepalive(cfg.keepalive),
 				v2.Timeout(cfg.timeout),
+				v2.MaxWindowSize(cfg.maxWindowSize),
 				v2.Channel(cfg.ch),
 				v2.TLS(cfg.tls),
 				v2.JSONDecoder(cfg.decoder))

--- a/server/v1/opts.go
+++ b/server/v1/opts.go
@@ -32,7 +32,7 @@ const defaultMaxWindowSize = 10000
 
 type options struct {
 	timeout       time.Duration
-	maxWindowSize int
+	maxWindowSize uint32
 	tls           *tls.Config
 	ch            chan *lj.Batch
 }
@@ -69,7 +69,7 @@ func Channel(c chan *lj.Batch) Option {
 // MaxWindowSize configures the maximum number of events a client may
 // announce in a single batch window frame. Frames exceeding this limit
 // are rejected. A value of zero or negative disables the check.
-func MaxWindowSize(n int) Option {
+func MaxWindowSize(n uint32) Option {
 	return func(opt *options) error {
 		opt.maxWindowSize = n
 		return nil

--- a/server/v1/opts.go
+++ b/server/v1/opts.go
@@ -28,10 +28,13 @@ import (
 // Option type for configuring server run options.
 type Option func(*options) error
 
+const defaultMaxWindowSize = 10000
+
 type options struct {
-	timeout time.Duration
-	tls     *tls.Config
-	ch      chan *lj.Batch
+	timeout       time.Duration
+	maxWindowSize int
+	tls           *tls.Config
+	ch            chan *lj.Batch
 }
 
 // Timeout configures server network timeouts.
@@ -63,10 +66,21 @@ func Channel(c chan *lj.Batch) Option {
 	}
 }
 
+// MaxWindowSize configures the maximum number of events a client may
+// announce in a single batch window frame. Frames exceeding this limit
+// are rejected. A value of zero or negative disables the check.
+func MaxWindowSize(n int) Option {
+	return func(opt *options) error {
+		opt.maxWindowSize = n
+		return nil
+	}
+}
+
 func applyOptions(opts []Option) (options, error) {
 	o := options{
-		timeout: 30 * time.Second,
-		tls:     nil,
+		timeout:       30 * time.Second,
+		maxWindowSize: defaultMaxWindowSize,
+		tls:           nil,
 	}
 
 	for _, opt := range opts {

--- a/server/v1/reader.go
+++ b/server/v1/reader.go
@@ -33,21 +33,23 @@ import (
 )
 
 type reader struct {
-	conn       net.Conn
-	in         *bufio.Reader
-	tlsState   *tls.ConnectionState
-	remoteAddr string
-	buf        []byte
-	timeout    time.Duration
+	conn          net.Conn
+	in            *bufio.Reader
+	tlsState      *tls.ConnectionState
+	remoteAddr    string
+	buf           []byte
+	timeout       time.Duration
+	maxWindowSize int
 }
 
-func newReader(c net.Conn, to time.Duration) *reader {
+func newReader(c net.Conn, to time.Duration, maxWindowSize int) *reader {
 	r := &reader{
-		conn:       c,
-		in:         bufio.NewReader(c),
-		remoteAddr: c.RemoteAddr().String(),
-		buf:        make([]byte, 0, 64),
-		timeout:    to,
+		conn:          c,
+		in:            bufio.NewReader(c),
+		remoteAddr:    c.RemoteAddr().String(),
+		buf:           make([]byte, 0, 64),
+		timeout:       to,
+		maxWindowSize: maxWindowSize,
 	}
 
 	if tlsConn, ok := c.(*tls.Conn); ok {
@@ -65,14 +67,18 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, err
 	}
 
-	if win[0] != protocol.CodeVersion && win[1] != protocol.CodeWindowSize {
-		log.Printf("Expected window from. Received %v", win[0:1])
+	if win[0] != protocol.CodeVersion || win[1] != protocol.CodeWindowSize {
+		log.Printf("Expected window frame. Received %v", win[0:2])
 		return nil, ErrProtocolError
 	}
 
 	count := int(binary.BigEndian.Uint32(win[2:]))
 	if count == 0 {
 		return nil, nil
+	}
+	if r.maxWindowSize > 0 && count > r.maxWindowSize {
+		log.Printf("Window size %d exceeds maximum %d", count, r.maxWindowSize)
+		return nil, ErrWindowTooLarge
 	}
 
 	if err := r.conn.SetReadDeadline(time.Now().Add(r.timeout)); err != nil {

--- a/server/v1/reader.go
+++ b/server/v1/reader.go
@@ -39,10 +39,10 @@ type reader struct {
 	remoteAddr    string
 	buf           []byte
 	timeout       time.Duration
-	maxWindowSize int
+	maxWindowSize uint32
 }
 
-func newReader(c net.Conn, to time.Duration, maxWindowSize int) *reader {
+func newReader(c net.Conn, to time.Duration, maxWindowSize uint32) *reader {
 	r := &reader{
 		conn:          c,
 		in:            bufio.NewReader(c),
@@ -72,7 +72,7 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, ErrProtocolError
 	}
 
-	count := int(binary.BigEndian.Uint32(win[2:]))
+	count := binary.BigEndian.Uint32(win[2:])
 	if count == 0 {
 		return nil, nil
 	}

--- a/server/v1/reader_test.go
+++ b/server/v1/reader_test.go
@@ -37,7 +37,7 @@ func TestReadBatchWindowTooLarge(t *testing.T) {
 		var frame [6]byte
 		frame[0] = protocol.CodeVersion
 		frame[1] = protocol.CodeWindowSize
-		binary.BigEndian.PutUint32(frame[2:], 200)
+		binary.BigEndian.PutUint32(frame[2:], 101)
 		_, _ = client.Write(frame[:])
 	}()
 

--- a/server/v1/reader_test.go
+++ b/server/v1/reader_test.go
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v1
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	protocol "github.com/elastic/go-lumber/protocol/v1" //nolint:depguard // We are testing.
+)
+
+func TestReadBatchWindowTooLarge(t *testing.T) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	r := newReader(srv, 5*time.Second, 100)
+
+	go func() {
+		var frame [6]byte
+		frame[0] = protocol.CodeVersion
+		frame[1] = protocol.CodeWindowSize
+		binary.BigEndian.PutUint32(frame[2:], 200)
+		_, _ = client.Write(frame[:])
+	}()
+
+	_, err := r.ReadBatch()
+	if err != ErrWindowTooLarge { //nolint:errorlint // Never wrapped.
+		t.Fatalf("ReadBatch() error = %v, want %v", err, ErrWindowTooLarge)
+	}
+}
+
+func TestReadBatchProtocolValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		frame   [6]byte
+		wantErr error
+	}{
+		{
+			name:    "wrong version byte",
+			frame:   [6]byte{'X', protocol.CodeWindowSize, 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+		{
+			name:    "wrong type byte",
+			frame:   [6]byte{protocol.CodeVersion, 'X', 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+		{
+			name:    "both wrong",
+			frame:   [6]byte{'X', 'Y', 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, srv := net.Pipe()
+			defer client.Close()
+			defer srv.Close()
+
+			r := newReader(srv, 5*time.Second, 10000)
+
+			go func() {
+				_, _ = client.Write(test.frame[:])
+			}()
+
+			_, err := r.ReadBatch()
+			if err != test.wantErr { //nolint:errorlint // Never wrapped.
+				t.Fatalf("ReadBatch() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadBatchMaxWindowSizeDisabled(t *testing.T) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	r := newReader(srv, 5*time.Second, 0)
+
+	go func() {
+		var frame [6]byte
+		frame[0] = protocol.CodeVersion
+		frame[1] = protocol.CodeWindowSize
+		binary.BigEndian.PutUint32(frame[2:], 50000)
+		_, _ = client.Write(frame[:])
+		client.Close()
+	}()
+
+	_, err := r.ReadBatch()
+	if err == ErrWindowTooLarge { //nolint:errorlint // Never wrapped.
+		t.Fatal("ReadBatch() returned ErrWindowTooLarge with maxWindowSize=0")
+	}
+}

--- a/server/v1/server.go
+++ b/server/v1/server.go
@@ -34,6 +34,10 @@ type Server struct {
 // conversation with lumberjack server.
 var ErrProtocolError = errors.New("lumberjack protocol error")
 
+// ErrWindowTooLarge is returned when a client sends a window size that
+// exceeds the configured maximum.
+var ErrWindowTooLarge = errors.New("lumberjack window size too large")
+
 // NewWithListener creates a new Server using an existing net.Listener.
 func NewWithListener(l net.Listener, opts ...Option) (*Server, error) {
 	return newServer(opts, func(cfg internal.Config) (*internal.Server, error) {
@@ -89,7 +93,7 @@ func newServer(
 	}
 
 	mkRW := func(client net.Conn) (internal.BatchReader, internal.ACKWriter, error) {
-		r := newReader(client, o.timeout)
+		r := newReader(client, o.timeout, o.maxWindowSize)
 		w := newWriter(client, o.timeout)
 		return r, w, nil
 	}

--- a/server/v2/opts.go
+++ b/server/v2/opts.go
@@ -34,7 +34,7 @@ const defaultMaxWindowSize = 10000
 type options struct {
 	timeout       time.Duration
 	keepalive     time.Duration
-	maxWindowSize int
+	maxWindowSize uint32
 	decoder       jsonDecoder
 	tls           *tls.Config
 	ch            chan *lj.Batch
@@ -92,7 +92,7 @@ func JSONDecoder(decoder func([]byte, interface{}) error) Option {
 // MaxWindowSize configures the maximum number of events a client may
 // announce in a single batch window frame. Frames exceeding this limit
 // are rejected. A value of zero or negative disables the check.
-func MaxWindowSize(n int) Option {
+func MaxWindowSize(n uint32) Option {
 	return func(opt *options) error {
 		opt.maxWindowSize = n
 		return nil

--- a/server/v2/opts.go
+++ b/server/v2/opts.go
@@ -29,12 +29,15 @@ import (
 // Option type for configuring server run options.
 type Option func(*options) error
 
+const defaultMaxWindowSize = 10000
+
 type options struct {
-	timeout   time.Duration
-	keepalive time.Duration
-	decoder   jsonDecoder
-	tls       *tls.Config
-	ch        chan *lj.Batch
+	timeout       time.Duration
+	keepalive     time.Duration
+	maxWindowSize int
+	decoder       jsonDecoder
+	tls           *tls.Config
+	ch            chan *lj.Batch
 }
 
 // Keepalive configures the keepalive interval returning an ACK of length 0 to
@@ -86,12 +89,23 @@ func JSONDecoder(decoder func([]byte, interface{}) error) Option {
 	}
 }
 
+// MaxWindowSize configures the maximum number of events a client may
+// announce in a single batch window frame. Frames exceeding this limit
+// are rejected. A value of zero or negative disables the check.
+func MaxWindowSize(n int) Option {
+	return func(opt *options) error {
+		opt.maxWindowSize = n
+		return nil
+	}
+}
+
 func applyOptions(opts []Option) (options, error) {
 	o := options{
-		decoder:   json.Unmarshal,
-		timeout:   30 * time.Second,
-		keepalive: 3 * time.Second,
-		tls:       nil,
+		decoder:       json.Unmarshal,
+		timeout:       30 * time.Second,
+		keepalive:     3 * time.Second,
+		maxWindowSize: defaultMaxWindowSize,
+		tls:           nil,
 	}
 
 	for _, opt := range opts {

--- a/server/v2/reader.go
+++ b/server/v2/reader.go
@@ -40,12 +40,12 @@ type reader struct {
 	remoteAddr    string
 	buf           []byte
 	timeout       time.Duration
-	maxWindowSize int
+	maxWindowSize uint32
 }
 
 type jsonDecoder func([]byte, interface{}) error
 
-func newReader(c net.Conn, to time.Duration, maxWindowSize int, jsonDecoder jsonDecoder) *reader {
+func newReader(c net.Conn, to time.Duration, maxWindowSize uint32, jsonDecoder jsonDecoder) *reader {
 	r := &reader{
 		conn:          c,
 		in:            bufio.NewReader(c),
@@ -76,7 +76,7 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, ErrProtocolError
 	}
 
-	count := int(binary.BigEndian.Uint32(win[2:]))
+	count := binary.BigEndian.Uint32(win[2:])
 	if count == 0 {
 		return nil, nil
 	}

--- a/server/v2/reader.go
+++ b/server/v2/reader.go
@@ -33,25 +33,27 @@ import (
 )
 
 type reader struct {
-	conn       net.Conn
-	in         *bufio.Reader
-	tlsState   *tls.ConnectionState
-	decoder    jsonDecoder
-	remoteAddr string
-	buf        []byte
-	timeout    time.Duration
+	conn          net.Conn
+	in            *bufio.Reader
+	tlsState      *tls.ConnectionState
+	decoder       jsonDecoder
+	remoteAddr    string
+	buf           []byte
+	timeout       time.Duration
+	maxWindowSize int
 }
 
 type jsonDecoder func([]byte, interface{}) error
 
-func newReader(c net.Conn, to time.Duration, jsonDecoder jsonDecoder) *reader {
+func newReader(c net.Conn, to time.Duration, maxWindowSize int, jsonDecoder jsonDecoder) *reader {
 	r := &reader{
-		conn:       c,
-		in:         bufio.NewReader(c),
-		decoder:    jsonDecoder,
-		remoteAddr: c.RemoteAddr().String(),
-		buf:        make([]byte, 0, 64),
-		timeout:    to,
+		conn:          c,
+		in:            bufio.NewReader(c),
+		decoder:       jsonDecoder,
+		remoteAddr:    c.RemoteAddr().String(),
+		buf:           make([]byte, 0, 64),
+		timeout:       to,
+		maxWindowSize: maxWindowSize,
 	}
 
 	if tlsConn, ok := c.(*tls.Conn); ok {
@@ -69,14 +71,18 @@ func (r *reader) ReadBatch() (*lj.Batch, error) {
 		return nil, err
 	}
 
-	if win[0] != protocol.CodeVersion && win[1] != protocol.CodeWindowSize {
-		log.Printf("Expected window from. Received %v", win[0:1])
+	if win[0] != protocol.CodeVersion || win[1] != protocol.CodeWindowSize {
+		log.Printf("Expected window frame. Received %v", win[0:2])
 		return nil, ErrProtocolError
 	}
 
 	count := int(binary.BigEndian.Uint32(win[2:]))
 	if count == 0 {
 		return nil, nil
+	}
+	if r.maxWindowSize > 0 && count > r.maxWindowSize {
+		log.Printf("Window size %d exceeds maximum %d", count, r.maxWindowSize)
+		return nil, ErrWindowTooLarge
 	}
 
 	if err := r.conn.SetReadDeadline(time.Now().Add(r.timeout)); err != nil {

--- a/server/v2/reader_test.go
+++ b/server/v2/reader_test.go
@@ -39,7 +39,7 @@ func TestReadBatchWindowTooLarge(t *testing.T) {
 		var frame [6]byte
 		frame[0] = protocol.CodeVersion
 		frame[1] = protocol.CodeWindowSize
-		binary.BigEndian.PutUint32(frame[2:], 200)
+		binary.BigEndian.PutUint32(frame[2:], 101)
 		_, _ = client.Write(frame[:])
 	}()
 
@@ -54,7 +54,7 @@ func TestReadBatchWindowAtLimit(t *testing.T) {
 	defer client.Close()
 	defer srv.Close()
 
-	r := newReader(srv, 5*time.Second, 100, json.Unmarshal)
+	r := newReader(srv, 5*time.Second, 1, json.Unmarshal)
 
 	// Send a window frame exactly at the limit, followed by valid JSON events.
 	go func() {

--- a/server/v2/reader_test.go
+++ b/server/v2/reader_test.go
@@ -1,0 +1,158 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	protocol "github.com/elastic/go-lumber/protocol/v2" //nolint:depguard // We are testing.
+)
+
+func TestReadBatchWindowTooLarge(t *testing.T) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	r := newReader(srv, 5*time.Second, 100, json.Unmarshal)
+
+	// Send a window frame with count exceeding the max.
+	go func() {
+		var frame [6]byte
+		frame[0] = protocol.CodeVersion
+		frame[1] = protocol.CodeWindowSize
+		binary.BigEndian.PutUint32(frame[2:], 200)
+		_, _ = client.Write(frame[:])
+	}()
+
+	_, err := r.ReadBatch()
+	if err != ErrWindowTooLarge { //nolint:errorlint // Never wrapped.
+		t.Fatalf("ReadBatch() error = %v, want %v", err, ErrWindowTooLarge)
+	}
+}
+
+func TestReadBatchWindowAtLimit(t *testing.T) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	r := newReader(srv, 5*time.Second, 100, json.Unmarshal)
+
+	// Send a window frame exactly at the limit, followed by valid JSON events.
+	go func() {
+		var frame [6]byte
+		frame[0] = protocol.CodeVersion
+		frame[1] = protocol.CodeWindowSize
+		binary.BigEndian.PutUint32(frame[2:], 1)
+		_, _ = client.Write(frame[:])
+
+		// Write one JSON data frame: version + type + seq(4) + payloadLen(4) + payload.
+		var hdr [2]byte
+		hdr[0] = protocol.CodeVersion
+		hdr[1] = protocol.CodeJSONDataFrame
+		_, _ = client.Write(hdr[:])
+
+		payload := []byte(`{"msg":"hello"}`)
+		var evHdr [8]byte
+		binary.BigEndian.PutUint32(evHdr[0:4], 1) // sequence number
+		binary.BigEndian.PutUint32(evHdr[4:8], uint32(len(payload)))
+		_, _ = client.Write(evHdr[:])
+		_, _ = client.Write(payload)
+	}()
+
+	batch, err := r.ReadBatch()
+	if err != nil {
+		t.Fatalf("ReadBatch() error = %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("ReadBatch() got %d events, want 1", len(batch.Events))
+	}
+}
+
+func TestReadBatchProtocolValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		frame   [6]byte
+		wantErr error
+	}{
+		{
+			name:    "wrong version byte",
+			frame:   [6]byte{'X', protocol.CodeWindowSize, 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+		{
+			name:    "wrong type byte",
+			frame:   [6]byte{protocol.CodeVersion, 'X', 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+		{
+			name:    "both wrong",
+			frame:   [6]byte{'X', 'Y', 0, 0, 0, 1},
+			wantErr: ErrProtocolError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, srv := net.Pipe()
+			defer client.Close()
+			defer srv.Close()
+
+			r := newReader(srv, 5*time.Second, 10000, json.Unmarshal)
+
+			go func() {
+				_, _ = client.Write(test.frame[:])
+			}()
+
+			_, err := r.ReadBatch()
+			if err != test.wantErr { //nolint:errorlint // Never wrapped.
+				t.Fatalf("ReadBatch() error = %v, want %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestReadBatchMaxWindowSizeDisabled(t *testing.T) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	// maxWindowSize=0 disables the check.
+	r := newReader(srv, 5*time.Second, 0, json.Unmarshal)
+
+	go func() {
+		var frame [6]byte
+		frame[0] = protocol.CodeVersion
+		frame[1] = protocol.CodeWindowSize
+		// Large window — would fail if check were active, but we won't
+		// actually read events, so just close the connection after sending.
+		binary.BigEndian.PutUint32(frame[2:], 50000)
+		_, _ = client.Write(frame[:])
+		client.Close()
+	}()
+
+	// The reader will try to read events and hit EOF from the closed conn,
+	// but it should NOT return ErrWindowTooLarge.
+	_, err := r.ReadBatch()
+	if err == ErrWindowTooLarge { //nolint:errorlint // Never wrapped.
+		t.Fatal("ReadBatch() returned ErrWindowTooLarge with maxWindowSize=0")
+	}
+}

--- a/server/v2/server.go
+++ b/server/v2/server.go
@@ -34,6 +34,10 @@ type Server struct {
 // conversation with lumberjack server.
 var ErrProtocolError = errors.New("lumberjack protocol error")
 
+// ErrWindowTooLarge is returned when a client sends a window size that
+// exceeds the configured maximum.
+var ErrWindowTooLarge = errors.New("lumberjack window size too large")
+
 // NewWithListener creates a new Server using an existing net.Listener.
 func NewWithListener(l net.Listener, opts ...Option) (*Server, error) {
 	return newServer(opts, func(cfg internal.Config) (*internal.Server, error) {
@@ -89,7 +93,7 @@ func newServer(
 	}
 
 	mkRW := func(client net.Conn) (internal.BatchReader, internal.ACKWriter, error) {
-		r := newReader(client, o.timeout, o.decoder)
+		r := newReader(client, o.timeout, o.maxWindowSize, o.decoder)
 		w := newWriter(client, o.timeout)
 		return r, w, nil
 	}


### PR DESCRIPTION
The Lumberjack protocol reader uses the window size from the wire directly as a slice capacity with no upper bound. A malicious client can send a single 6-byte frame announcing a window of 2^32-1 events, causing a ~64 GB allocation attempt that crashes the process.

Add a MaxWindowSize option (default 10,000) that rejects frames exceeding the limit before any allocation occurs. The limit is configurable at the top-level server package and per-protocol (v1/v2) levels following the existing Option pattern. A value of zero disables the check.

Also fix the protocol validation condition which incorrectly used && instead of ||, allowing frames through when only one of the two header bytes was wrong.